### PR TITLE
Remove max connection limit ( -x, --max-connection-per-server=NUM)

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -12,6 +12,7 @@ on:
       - released
   schedule:
     - cron: "0 0 * * 6"
+  workflow_dispatch:
 
 jobs:
   create-prerelease:

--- a/build.sh
+++ b/build.sh
@@ -86,7 +86,8 @@ apt install -y g++ \
   autopoint \
   patch \
   wget \
-  unzip
+  unzip \
+  curl
 
 BUILD_ARCH="$(gcc -dumpmachine)"
 TARGET_ARCH="${CROSS_HOST%%-*}"
@@ -436,6 +437,8 @@ build_aria2() {
   mkdir -p "/usr/src/aria2-${aria2_tag}"
   tar -zxf "${DOWNLOADS_DIR}/aria2-${aria2_tag}.tar.gz" --strip-components=1 -C "/usr/src/aria2-${aria2_tag}"
   cd "/usr/src/aria2-${aria2_tag}"
+  # remove server max connection limit
+  curl -fsSL "https://aur.archlinux.org/cgit/aur.git/plain/unlimited-max-connection.patch?h=aria2-unlimited" | patch -p1
   if [ ! -f ./configure ]; then
     autoreconf -i
   fi


### PR DESCRIPTION
`aria2c` defaults to a maximum of 16 connections per server, which is too small for downloading large files.
This PR remove such limits so that one can easily saturate the network bandwidth when downloading.

Before:
```
 -x, --max-connection-per-server=NUM The maximum number of connections to one
                              server for each download.

                              Possible Values: 1-16
                              Default: 1
                              Tags: #basic, #http, #ftp
```

After:
```
 -x, --max-connection-per-server=NUM The maximum number of connections to one
                              server for each download.

                              Possible Values: 1-*
                              Default: 1
                              Tags: #basic, #http, #ftp
```