### PR TITLE
Fix Linux targets and add i686 Linux target

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,6 +1,7 @@
 name: "Build and Release"
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "*"
@@ -50,6 +51,7 @@ jobs:
           - mips-unknown-linux-musl
           - mipsel-unknown-linux-musl
           - mips64-unknown-linux-musl
+          - i686-unknown-linux-musl
           - x86_64-unknown-linux-musl
           - x86_64-w64-mingw32
           - i686-w64-mingw32


### PR DESCRIPTION
It works like the other Linux targets, which now actually build. Unfortunately, the `*-w64-mingw32` targets still fail.